### PR TITLE
Pipe events to head so that the process terminates

### DIFF
--- a/bin/docker-tc.sh
+++ b/bin/docker-tc.sh
@@ -79,5 +79,5 @@ while read DOCKER_EVENT; do
     done < <(echo -e "$NETWORK_NAMES")
 done < <(
     docker ps -q;
-    docker events --filter event=start
+    docker events --filter event=start | head -n1
 )


### PR DESCRIPTION
By piping the output to head the command returns the first event that happens and then closes the process after the second event. It's not ideal but at least it prevents the memory leak.